### PR TITLE
solve double quote conflict on cloudfront invalidation paths

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ sh -c "aws s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
               --no-progress \
               ${ENDPOINT_APPEND} $*"
               
-sh -c "aws cloudfront create-invalidation --distribution-id ${DISTRIBUTION_ID} --paths "/*" --profile s3-sync-action"
+sh -c 'aws cloudfront create-invalidation --distribution-id ${DISTRIBUTION_ID} --paths "/*" --profile s3-sync-action'
 
 # Clear out credentials after we're done.
 # We need to re-run `aws configure` with bogus input instead of


### PR DESCRIPTION
Hi there @kefranabg,
First of all, thanks for the beautiful Github action!
I found a bug when creating the Cloudfront invalidation:
It's a collision of double quotes in the command. `*` is a reserved word, so this is causing that the invalidation is an expansion of the local files, not `/*`. See more info [here](https://stackoverflow.com/questions/37759949/aws-cli-cloudfront-invalidate-all-files)
See picture attached on my cloudfront invalidation:
<img width="198" alt="Screenshot 2021-09-16 at 19 58 19" src="https://user-images.githubusercontent.com/7213117/133662256-549778db-00d7-4866-860d-268e5247f9b3.png">

After the change, the invalidation is created correctly
<img width="113" alt="Screenshot 2021-09-16 at 19 58 24" src="https://user-images.githubusercontent.com/7213117/133662284-13c6b2f7-ce8e-41aa-b74e-52428b75a5f7.png">


Thanks again and hope this is useful! 